### PR TITLE
fix: validate JWT token on page load

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -207,3 +207,13 @@ def google_callback(
         data={"sub": user["email"]}, expires_delta=access_token_expires
     )
     return RedirectResponse(f"{settings.frontend_url}/auth/callback?token={access_token}")
+
+
+# ── Validate Token ────────────────────────────────────────────────────
+@router.get("/validate-token")
+def validate_token(current_user: dict = Depends(get_current_user)):
+    """
+    Lightweight endpoint to validate the current JWT.
+    Returns 200 if valid, 401 if expired/invalid (handled by get_current_user).
+    """
+    return {"valid": True, "email": current_user["email"]}

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -7,9 +7,17 @@ import { Toaster } from "@/components/ui/sonner";
 
 function AuthHydration() {
     const hydrate = useAuthStore((s) => s.hydrate);
+    const validateToken = useAuthStore((s) => s.validateToken);
+    const isHydrated = useAuthStore((s) => s.isHydrated);
     useEffect(() => {
         hydrate();
     }, [hydrate]);
+    // After hydration, validate the token against the backend
+    useEffect(() => {
+        if (isHydrated) {
+            validateToken();
+        }
+    }, [isHydrated, validateToken]);
     return null;
 }
 

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { UserResponse } from "@/types/api";
+import api from "@/lib/api";
 
 interface AuthState {
     user: UserResponse | null;
@@ -10,6 +11,7 @@ interface AuthState {
     logout: () => void;
     hydrate: () => void;
     setUser: (user: UserResponse) => void;
+    validateToken: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -56,5 +58,17 @@ export const useAuthStore = create<AuthState>((set) => ({
             localStorage.setItem("buslens_user", JSON.stringify(user));
         }
         set({ user });
+    },
+
+    validateToken: async () => {
+        const state = useAuthStore.getState();
+        if (!state.token || !state.isAuthenticated) return;
+        try {
+            await api.get("/auth/validate-token");
+            // Token is valid — no action needed
+        } catch {
+            // Token is expired or invalid — auto-logout
+            state.logout();
+        }
     },
 }));


### PR DESCRIPTION
- Backend: GET /auth/validate-token lightweight endpoint
- Frontend: validateToken() action in auth store
- Frontend: AuthHydration calls validateToken after hydration
- Auto-logs out users with expired/invalid tokens on page load
- Prevents stale authenticated state until user performs an action

closes #12 