### PR TITLE
feat: add delete account functionality

### DIFF
--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -3,8 +3,9 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.api.deps import get_current_user, get_verified_user
-from app.schemas.user import FavoriteCreate, FavoriteResponse, HistoryCreate, HistoryResponse, UserResponse
+from app.schemas.user import FavoriteCreate, FavoriteResponse, HistoryCreate, HistoryResponse, UserResponse, DeleteAccountRequest
 from app.repositories import users_repo
+from app.core.security import verify_password
 
 router = APIRouter()
 
@@ -94,4 +95,33 @@ def clear_favorites(
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+@router.delete("/me", status_code=200)
+def delete_account(
+    body: DeleteAccountRequest,
+    db: Session = Depends(get_db),
+    current_user: dict = Depends(get_current_user),
+):
+    """
+    Permanently delete the current user's account and all associated data.
+    Local users must confirm with their password.
+    Google-only users can delete without password.
+    """
+    # For local auth users, require password confirmation
+    if current_user.get("hashed_password"):
+        if not body.password:
+            raise HTTPException(
+                status_code=400,
+                detail="Password is required to delete your account.",
+            )
+        if not verify_password(body.password, current_user["hashed_password"]):
+            raise HTTPException(
+                status_code=403,
+                detail="Incorrect password. Account deletion cancelled.",
+            )
+
+    try:
+        users_repo.delete_user(db, current_user["id"])
+        return {"message": "Account deleted successfully"}
+    except ValueError as e:
+        raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/repositories/users_repo.py
+++ b/backend/app/repositories/users_repo.py
@@ -142,3 +142,18 @@ def clear_user_favorites(db: Session, user_id: int):
     except SQLAlchemyError as e:
         db.rollback()
         raise ValueError("Database error while clearing user favorites") from e
+
+def delete_user(db: Session, user_id: int) -> None:
+    """
+    Delete a user and all associated data.
+    Clears: favorites, search_history, otp_codes, then the user record.
+    """
+    try:
+        db.execute(text("DELETE FROM favorites WHERE user_id = :uid"), {"uid": user_id})
+        db.execute(text("DELETE FROM search_history WHERE user_id = :uid"), {"uid": user_id})
+        db.execute(text("DELETE FROM otp_codes WHERE user_id = :uid"), {"uid": user_id})
+        db.execute(text("DELETE FROM users WHERE id = :uid"), {"uid": user_id})
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise ValueError("Database error while deleting user account") from e

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -56,3 +56,7 @@ class HistoryResponse(BaseModel):
     from_stop_name: Optional[str] = None
     to_stop_name: Optional[str] = None
     searched_at: datetime
+
+class DeleteAccountRequest(BaseModel):
+    """Password confirmation for account deletion. Empty string for Google-only accounts."""
+    password: str = ""

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,6 +15,8 @@ import {
     ShieldCheck,
     Mail,
     RefreshCw,
+    Lock,
+    AlertTriangle,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -38,6 +40,95 @@ import { toast } from "sonner";
 import api from "@/lib/api";
 import { PageBackground } from "@/components/layout/PageBackground";
 import type { UserResponse } from "@/types/api";
+
+// ── Delete Account Section ───────────────────────────────────────────
+function DeleteAccountSection({ user }: { user: UserResponse | null }) {
+    const router = useRouter();
+    const { logout } = useAuthStore();
+    const [showDialog, setShowDialog] = useState(false);
+    const [password, setPassword] = useState("");
+    const [deleting, setDeleting] = useState(false);
+
+    const isGoogleOnly = user?.auth_provider === "google";
+
+    const handleDelete = async () => {
+        setDeleting(true);
+        try {
+            await api.delete("/users/me", {
+                data: { password: isGoogleOnly ? "" : password },
+            });
+            toast.success("Account deleted successfully.");
+            logout();
+            router.push("/");
+        } catch (err: unknown) {
+            const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+            toast.error(detail || "Failed to delete account");
+        } finally {
+            setDeleting(false);
+            setShowDialog(false);
+            setPassword("");
+        }
+    };
+
+    return (
+        <AlertDialog open={showDialog} onOpenChange={setShowDialog}>
+            <AlertDialogTrigger asChild>
+                <Button
+                    variant="outline"
+                    className="gap-2 border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                >
+                    <Trash2 className="h-4 w-4" />
+                    Delete my account
+                </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle className="flex items-center gap-2 text-destructive">
+                        <AlertTriangle className="h-5 w-5" />
+                        Delete your account?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription className="space-y-2">
+                        <span className="block">
+                            This will permanently delete your account, favorites, search history, and all associated data.
+                        </span>
+                        <span className="block font-semibold text-destructive/80">
+                            This action cannot be undone.
+                        </span>
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                {!isGoogleOnly && (
+                    <div className="py-2">
+                        <label className="text-sm font-medium text-muted-foreground block mb-2">
+                            Confirm your password
+                        </label>
+                        <div className="relative">
+                            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground/50" />
+                            <input
+                                type="password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                placeholder="Enter your password"
+                                className="w-full h-10 pl-9 pr-3 rounded-lg text-sm bg-background/50 border border-border/50 text-foreground placeholder:text-muted-foreground/40 outline-none focus:border-destructive/50 transition-colors"
+                            />
+                        </div>
+                    </div>
+                )}
+
+                <AlertDialogFooter>
+                    <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+                    <Button
+                        variant="destructive"
+                        onClick={handleDelete}
+                        disabled={deleting || (!isGoogleOnly && !password)}
+                    >
+                        {deleting ? "Deleting..." : "Delete permanently"}
+                    </Button>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}
 
 function DashboardContent() {
     const router = useRouter();
@@ -508,6 +599,20 @@ function DashboardContent() {
                         ))}
                     </TabsContent>
                 </Tabs>
+
+                {/* Danger Zone — Delete Account */}
+                <div className="mt-12 pt-8" style={{ borderTop: "1px solid oklch(1 0.02 285 / 8%)" }}>
+                    <h3
+                        className="text-lg font-bold mb-1 text-destructive"
+                        style={{ fontFamily: "var(--font-heading), sans-serif" }}
+                    >
+                        Danger Zone
+                    </h3>
+                    <p className="text-sm text-muted-foreground mb-4">
+                        Permanently delete your account and all associated data. This action cannot be undone.
+                    </p>
+                    <DeleteAccountSection user={user} />
+                </div>
             </div>
         </PageBackground>
     );


### PR DESCRIPTION
- Backend: DELETE /users/me endpoint with password confirmation
- Backend: delete_user repo function (cascading: favorites, history, OTPs, user)
- Backend: DeleteAccountRequest schema for password confirmation
- Frontend: Danger Zone section on dashboard page
- Frontend: AlertDialog with password entry for local users
- Frontend: Google-only users can delete without password
- Security: password verification required for local auth users

closes #14 