### PR TITLE
feat: add reset password functionality

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -12,17 +12,19 @@ import httpx
 from app.db.session import get_db
 from app.core.security import verify_password, create_access_token
 from app.core.config import settings
-from app.schemas.user import UserCreate, UserResponse, Token, OTPRequest, OTPResponse
+from app.schemas.user import UserCreate, UserResponse, Token, OTPRequest, OTPResponse, ForgotPasswordRequest, ResetPasswordRequest
 from app.repositories.users_repo import (
     get_user_by_email,
     create_user,
     get_user_by_google_id,
     create_google_user,
     link_google_to_user,
+    update_user_password,
 )
 from app.repositories.otp_repo import create_otp, verify_otp, get_seconds_since_last_otp
-from app.services.email_service import generate_otp, send_otp_email, send_welcome_email
+from app.services.email_service import generate_otp, send_otp_email, send_welcome_email, send_password_reset_email
 from app.api.deps import get_current_user
+from app.core.security import verify_password, create_access_token, get_password_hash
 
 logger = logging.getLogger(__name__)
 
@@ -207,3 +209,60 @@ def google_callback(
         data={"sub": user["email"]}, expires_delta=access_token_expires
     )
     return RedirectResponse(f"{settings.frontend_url}/auth/callback?token={access_token}")
+
+
+# ── Forgot Password (send OTP to email) ───────────────────────────────
+@router.post("/forgot-password", response_model=OTPResponse)
+def forgot_password(body: ForgotPasswordRequest, db: Session = Depends(get_db)):
+    """
+    Send a password reset OTP to the user's email.
+    Always returns success message (even if email not found) to prevent email enumeration.
+    """
+    user = get_user_by_email(db, email=body.email)
+    if user:
+        # Only allow for local auth users who have a password
+        if user.get("auth_provider") == "google" and not user.get("hashed_password"):
+            # Google-only users can't reset password — but don't leak this info
+            return {"message": "If an account exists with this email, a reset code has been sent."}
+
+        # Rate limit: check last OTP was sent more than 60 seconds ago
+        elapsed = get_seconds_since_last_otp(db, user["id"])
+        if elapsed is not None and elapsed < 60:
+            remaining = int(60 - elapsed)
+            if remaining > 0:
+                raise HTTPException(
+                    status_code=429,
+                    detail=f"Please wait {remaining} seconds before requesting a new code.",
+                )
+
+        otp = generate_otp()
+        create_otp(db, user["id"], otp, purpose="password_reset")
+        send_password_reset_email(body.email, otp)
+
+    # Always return the same message to prevent email enumeration
+    return {"message": "If an account exists with this email, a reset code has been sent."}
+
+
+# ── Reset Password (verify OTP + set new password) ────────────────────
+@router.post("/reset-password", response_model=OTPResponse)
+def reset_password(body: ResetPasswordRequest, db: Session = Depends(get_db)):
+    """
+    Verify the password reset OTP and set a new password.
+    """
+    user = get_user_by_email(db, email=body.email)
+    if not user:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid or expired reset code.",
+        )
+
+    if not verify_otp(db, user["id"], body.otp, purpose="password_reset"):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid or expired reset code. Please request a new one.",
+        )
+
+    new_hash = get_password_hash(body.new_password)
+    update_user_password(db, user["id"], new_hash)
+
+    return {"message": "Password reset successfully. You can now log in with your new password."}

--- a/backend/app/repositories/otp_repo.py
+++ b/backend/app/repositories/otp_repo.py
@@ -5,18 +5,18 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.core.config import settings
 
 
-def create_otp(db: Session, user_id: int, code: str) -> None:
-    """Insert a new OTP, invalidating any previous unused ones for this user."""
+def create_otp(db: Session, user_id: int, code: str, purpose: str = "email_verify") -> None:
+    """Insert a new OTP, invalidating any previous unused ones for this user and purpose."""
     try:
-        # Invalidate old OTPs
+        # Invalidate old OTPs for this user and purpose
         db.execute(
-            text("UPDATE otp_codes SET used = TRUE WHERE user_id = :uid AND used = FALSE"),
-            {"uid": user_id}
+            text("UPDATE otp_codes SET used = TRUE WHERE user_id = :uid AND used = FALSE AND purpose = :purpose"),
+            {"uid": user_id, "purpose": purpose}
         )
         db.execute(
-            text("""INSERT INTO otp_codes (user_id, code, expires_at)
-                    VALUES (:uid, :code, NOW() + INTERVAL :exp MINUTE)"""),
-            {"uid": user_id, "code": code, "exp": settings.otp_expire_minutes}
+            text("""INSERT INTO otp_codes (user_id, code, purpose, expires_at)
+                    VALUES (:uid, :code, :purpose, NOW() + INTERVAL :exp MINUTE)"""),
+            {"uid": user_id, "code": code, "purpose": purpose, "exp": settings.otp_expire_minutes}
         )
         db.commit()
     except SQLAlchemyError as e:
@@ -24,26 +24,31 @@ def create_otp(db: Session, user_id: int, code: str) -> None:
         raise ValueError("Database error while creating OTP") from e
 
 
-def verify_otp(db: Session, user_id: int, code: str) -> bool:
+def verify_otp(db: Session, user_id: int, code: str, purpose: str = "email_verify") -> bool:
     """
     Check if the OTP is valid (correct, not expired, not used).
-    If valid: marks OTP as used AND sets user.is_verified = True.
+    If valid and purpose is email_verify: marks OTP as used AND sets user.is_verified = True.
+    If valid and purpose is password_reset: just marks OTP as used.
     """
     try:
         row = db.execute(
             text("""SELECT id FROM otp_codes
-                    WHERE user_id = :uid AND code = :code
+                    WHERE user_id = :uid AND code = :code AND purpose = :purpose
                       AND used = FALSE AND expires_at > NOW()
                     ORDER BY created_at DESC LIMIT 1"""),
-            {"uid": user_id, "code": code}
+            {"uid": user_id, "code": code, "purpose": purpose}
         ).mappings().first()
 
         if not row:
             return False
 
-        # Mark OTP as used and verify the user
+        # Mark OTP as used
         db.execute(text("UPDATE otp_codes SET used = TRUE WHERE id = :id"), {"id": row["id"]})
-        db.execute(text("UPDATE users SET is_verified = TRUE WHERE id = :uid"), {"uid": user_id})
+        
+        # Only verify user email if the purpose is email verification
+        if purpose == "email_verify":
+            db.execute(text("UPDATE users SET is_verified = TRUE WHERE id = :uid"), {"uid": user_id})
+        
         db.commit()
         return True
     except SQLAlchemyError as e:

--- a/backend/app/repositories/users_repo.py
+++ b/backend/app/repositories/users_repo.py
@@ -142,3 +142,13 @@ def clear_user_favorites(db: Session, user_id: int):
     except SQLAlchemyError as e:
         db.rollback()
         raise ValueError("Database error while clearing user favorites") from e
+
+def update_user_password(db: Session, user_id: int, new_hashed_password: str) -> None:
+    """Update a user's password hash."""
+    try:
+        sql = text("UPDATE users SET hashed_password = :pwd WHERE id = :uid")
+        db.execute(sql, {"pwd": new_hashed_password, "uid": user_id})
+        db.commit()
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise ValueError("Database error while updating password") from e

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 from datetime import datetime
 from typing import Optional
 
@@ -56,3 +56,18 @@ class HistoryResponse(BaseModel):
     from_stop_name: Optional[str] = None
     to_stop_name: Optional[str] = None
     searched_at: datetime
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+class ResetPasswordRequest(BaseModel):
+    email: EmailStr
+    otp: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def password_min_length(cls, v: str) -> str:
+        if len(v) < 6:
+            raise ValueError("Password must be at least 6 characters")
+        return v

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -121,3 +121,56 @@ def send_welcome_email(to_email: str) -> bool:
     except Exception as e:
         logger.error("Failed to send welcome email to %s: %s", to_email, e)
         return False
+
+
+def send_password_reset_email(to_email: str, otp: str) -> bool:
+    """
+    Send a password reset OTP via SMTP.
+    Returns True on success, False on failure.
+    """
+    if not settings.smtp_user or not settings.smtp_password:
+        logger.warning("SMTP credentials not configured — skipping reset email to %s", to_email)
+        return False
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = f"BusLens — Password Reset Code: {otp}"
+    msg["From"] = settings.smtp_user
+    msg["To"] = to_email
+
+    html = f"""
+    <div style="font-family: 'Inter', 'Segoe UI', Arial, sans-serif; max-width: 480px; margin: auto;
+                padding: 32px; background: #ffffff; border-radius: 16px; border: 1px solid #eaeaea;
+                box-shadow: 0 4px 20px rgba(0,0,0,0.05);">
+      <div style="text-align: center; margin-bottom: 24px;">
+        <h1 style="color: #6d28d9; margin: 0; font-size: 28px; font-weight: 800; letter-spacing: -0.5px;">BusLens</h1>
+        <div style="width: 40px; height: 4px; background: #8b5cf6; margin: 8px auto 0; border-radius: 2px;"></div>
+      </div>
+      <h2 style="margin: 0 0 12px 0; color: #1e293b; font-size: 20px;">Reset your password</h2>
+      <p style="color: #64748b; margin: 0 0 24px 0; font-size: 15px; line-height: 1.5;">
+        We received a request to reset your password. Use the code below to set a new password.
+      </p>
+      <div style="font-size: 36px; font-weight: 700; letter-spacing: 12px;
+                  padding: 20px 24px; background: #f8fafc; border: 2px dashed #cbd5e1;
+                  border-radius: 12px; text-align: center; color: #0f172a; margin-bottom: 24px;">
+        {otp}
+      </div>
+      <div style="border-top: 1px solid #f1f5f9; padding-top: 20px;">
+        <p style="color: #94a3b8; margin: 0; font-size: 13px;">
+          This code expires in {settings.otp_expire_minutes} minutes.<br>
+          If you didn't request a password reset, you can safely ignore this email.
+        </p>
+      </div>
+    </div>
+    """
+    msg.attach(MIMEText(html, "html"))
+
+    try:
+        with smtplib.SMTP(settings.smtp_host, settings.smtp_port, timeout=10) as server:
+            server.starttls()
+            server.login(settings.smtp_user, settings.smtp_password)
+            server.sendmail(settings.smtp_user, to_email, msg.as_string())
+        logger.info("Password reset email sent to %s", to_email)
+        return True
+    except Exception as e:
+        logger.error("Failed to send password reset email to %s: %s", to_email, e)
+        return False

--- a/backend/migrations/003_password_reset.sql
+++ b/backend/migrations/003_password_reset.sql
@@ -1,0 +1,5 @@
+-- Migration: Add password_reset purpose to otp_codes
+-- Run this against your buslens2 database
+
+ALTER TABLE otp_codes
+  MODIFY COLUMN purpose ENUM('email_verify', 'password_reset') NOT NULL DEFAULT 'email_verify';

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Mail, ArrowLeft, KeyRound } from "lucide-react";
+import { toast } from "sonner";
+import api from "@/lib/api";
+import { BeamsBackground } from "@/components/ui/beams-background";
+import { AuthFloatingNav } from "@/components/layout/AuthFloatingNav";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { forgotPasswordSchema, type ForgotPasswordFormData } from "@/lib/validations";
+
+export default function ForgotPasswordPage() {
+    const router = useRouter();
+    const [loading, setLoading] = useState(false);
+    const [sent, setSent] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        getValues,
+        formState: { errors },
+    } = useForm<ForgotPasswordFormData>({
+        resolver: zodResolver(forgotPasswordSchema),
+    });
+
+    const onSubmit = async (data: ForgotPasswordFormData) => {
+        setLoading(true);
+        try {
+            await api.post("/auth/forgot-password", { email: data.email });
+            setSent(true);
+            toast.success("Reset code sent! Check your email.");
+        } catch (err: unknown) {
+            const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+            if (detail?.includes("wait")) {
+                toast.error(detail);
+            } else {
+                // Always show success to prevent email enumeration
+                setSent(true);
+                toast.success("If an account exists, a reset code has been sent.");
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <BeamsBackground intensity="medium" className="min-h-screen">
+            <div className="flex items-center justify-center min-h-screen p-4 sm:p-6">
+                <div
+                    className="relative w-full max-w-md rounded-3xl overflow-visible shadow-2xl shadow-black/50"
+                    style={{
+                        background: "oklch(0.16 0.025 285 / 80%)",
+                        border: "1px solid oklch(1 0.02 285 / 8%)",
+                        backdropFilter: "blur(20px)",
+                    }}
+                >
+                    <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20">
+                        <AuthFloatingNav />
+                    </div>
+
+                    <div className="flex flex-col justify-center pt-20 pb-8 px-6 sm:px-12">
+                        <div className="w-full max-w-sm mx-auto">
+                            {/* Back link */}
+                            <Link
+                                href="/login"
+                                className="inline-flex items-center gap-1.5 text-sm font-medium mb-6 transition-colors hover:opacity-80"
+                                style={{ color: "oklch(0.65 0.03 285)" }}
+                            >
+                                <ArrowLeft className="h-4 w-4" />
+                                Back to login
+                            </Link>
+
+                            {!sent ? (
+                                <>
+                                    {/* Header */}
+                                    <div className="mb-8">
+                                        <div
+                                            className="flex h-14 w-14 items-center justify-center rounded-2xl mb-5"
+                                            style={{ background: "oklch(0.72 0.12 290 / 15%)" }}
+                                        >
+                                            <KeyRound className="h-7 w-7" style={{ color: "oklch(0.78 0.12 290)" }} />
+                                        </div>
+                                        <h1
+                                            className="text-2xl font-bold text-white"
+                                            style={{ fontFamily: "var(--font-heading), sans-serif" }}
+                                        >
+                                            Forgot password?
+                                        </h1>
+                                        <p className="text-sm mt-2" style={{ color: "oklch(0.60 0.03 285)" }}>
+                                            No worries! Enter your email and we&apos;ll send you a reset code.
+                                        </p>
+                                    </div>
+
+                                    {/* Form */}
+                                    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+                                        <div>
+                                            <label
+                                                htmlFor="forgot-email"
+                                                className="block text-sm font-medium mb-2"
+                                                style={{ color: "oklch(0.70 0.03 285)" }}
+                                            >
+                                                Email address
+                                            </label>
+                                            <div className="relative">
+                                                <Mail
+                                                    className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4"
+                                                    style={{ color: "oklch(0.45 0.03 285)" }}
+                                                />
+                                                <input
+                                                    id="forgot-email"
+                                                    type="email"
+                                                    {...register("email")}
+                                                    placeholder="you@example.com"
+                                                    className={`w-full h-12 pl-10 pr-4 rounded-xl text-sm text-white placeholder:text-[oklch(0.40_0.02_285)] auth-input outline-none transition-all duration-200 ${errors.email ? "border border-red-500" : ""}`}
+                                                />
+                                            </div>
+                                            {errors.email && (
+                                                <p className="text-red-500 text-xs mt-1">{errors.email.message}</p>
+                                            )}
+                                        </div>
+
+                                        <button
+                                            type="submit"
+                                            disabled={loading}
+                                            className="w-full h-12 rounded-xl text-[15px] font-semibold text-white transition-all duration-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:brightness-110 active:scale-[0.98] shadow-lg"
+                                            style={{
+                                                background: "linear-gradient(135deg, oklch(0.68 0.15 280), oklch(0.72 0.12 295))",
+                                                boxShadow: "0 4px 20px oklch(0.72 0.12 290 / 25%)",
+                                            }}
+                                        >
+                                            {loading ? "Sending..." : "Send reset code"}
+                                        </button>
+                                    </form>
+                                </>
+                            ) : (
+                                <>
+                                    {/* Success state */}
+                                    <div className="text-center">
+                                        <div
+                                            className="flex h-16 w-16 items-center justify-center rounded-2xl mx-auto mb-5"
+                                            style={{ background: "oklch(0.72 0.18 150 / 15%)" }}
+                                        >
+                                            <Mail className="h-8 w-8" style={{ color: "oklch(0.75 0.22 150)" }} />
+                                        </div>
+                                        <h2
+                                            className="text-xl font-bold text-white mb-2"
+                                            style={{ fontFamily: "var(--font-heading), sans-serif" }}
+                                        >
+                                            Check your email
+                                        </h2>
+                                        <p className="text-sm mb-6" style={{ color: "oklch(0.60 0.03 285)" }}>
+                                            We sent a reset code to{" "}
+                                            <span className="font-medium" style={{ color: "oklch(0.78 0.12 290)" }}>
+                                                {getValues("email")}
+                                            </span>
+                                        </p>
+
+                                        <button
+                                            onClick={() =>
+                                                router.push(`/reset-password?email=${encodeURIComponent(getValues("email"))}`)
+                                            }
+                                            className="w-full h-12 rounded-xl text-[15px] font-semibold text-white transition-all duration-200 cursor-pointer hover:brightness-110 active:scale-[0.98] shadow-lg"
+                                            style={{
+                                                background: "linear-gradient(135deg, oklch(0.68 0.15 280), oklch(0.72 0.12 295))",
+                                                boxShadow: "0 4px 20px oklch(0.72 0.12 290 / 25%)",
+                                            }}
+                                        >
+                                            Enter reset code
+                                        </button>
+
+                                        <button
+                                            onClick={() => setSent(false)}
+                                            className="mt-3 text-sm font-medium transition-colors hover:opacity-80"
+                                            style={{ color: "oklch(0.65 0.03 285)" }}
+                                        >
+                                            Didn&apos;t receive it? Try again
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </BeamsBackground>
+    );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -198,6 +198,15 @@ export default function LoginPage() {
                                     )}
                                 </div>
 
+                                <div className="flex justify-end">
+                                    <Link
+                                        href="/forgot-password"
+                                        className="text-sm font-medium transition-colors hover:underline"
+                                        style={{ color: "oklch(0.70 0.08 290)" }}
+                                    >
+                                        Forgot password?
+                                    </Link>
+                                </div>
                                 <button
                                     type="submit"
                                     disabled={loading}

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Lock, Eye, EyeOff, ArrowLeft, ShieldCheck, Mail } from "lucide-react";
+import { toast } from "sonner";
+import api from "@/lib/api";
+import { BeamsBackground } from "@/components/ui/beams-background";
+import { AuthFloatingNav } from "@/components/layout/AuthFloatingNav";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { resetPasswordSchema, type ResetPasswordFormData } from "@/lib/validations";
+
+function ResetPasswordContent() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const emailFromParams = searchParams.get("email") || "";
+
+    const [loading, setLoading] = useState(false);
+    const [success, setSuccess] = useState(false);
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<ResetPasswordFormData>({
+        resolver: zodResolver(resetPasswordSchema),
+    });
+
+    const onSubmit = async (data: ResetPasswordFormData) => {
+        if (!emailFromParams) {
+            toast.error("Missing email. Please go back and try again.");
+            return;
+        }
+        setLoading(true);
+        try {
+            await api.post("/auth/reset-password", {
+                email: emailFromParams,
+                otp: data.otp,
+                new_password: data.newPassword,
+            });
+            setSuccess(true);
+            toast.success("Password reset successfully!");
+        } catch (err: unknown) {
+            const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+            toast.error(detail || "Failed to reset password. Please try again.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <BeamsBackground intensity="medium" className="min-h-screen">
+            <div className="flex items-center justify-center min-h-screen p-4 sm:p-6">
+                <div
+                    className="relative w-full max-w-md rounded-3xl overflow-visible shadow-2xl shadow-black/50"
+                    style={{
+                        background: "oklch(0.16 0.025 285 / 80%)",
+                        border: "1px solid oklch(1 0.02 285 / 8%)",
+                        backdropFilter: "blur(20px)",
+                    }}
+                >
+                    <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20">
+                        <AuthFloatingNav />
+                    </div>
+
+                    <div className="flex flex-col justify-center pt-20 pb-8 px-6 sm:px-12">
+                        <div className="w-full max-w-sm mx-auto">
+                            {/* Back link */}
+                            <Link
+                                href="/forgot-password"
+                                className="inline-flex items-center gap-1.5 text-sm font-medium mb-6 transition-colors hover:opacity-80"
+                                style={{ color: "oklch(0.65 0.03 285)" }}
+                            >
+                                <ArrowLeft className="h-4 w-4" />
+                                Back
+                            </Link>
+
+                            {!success ? (
+                                <>
+                                    {/* Header */}
+                                    <div className="mb-8">
+                                        <div
+                                            className="flex h-14 w-14 items-center justify-center rounded-2xl mb-5"
+                                            style={{ background: "oklch(0.72 0.12 290 / 15%)" }}
+                                        >
+                                            <Lock className="h-7 w-7" style={{ color: "oklch(0.78 0.12 290)" }} />
+                                        </div>
+                                        <h1
+                                            className="text-2xl font-bold text-white"
+                                            style={{ fontFamily: "var(--font-heading), sans-serif" }}
+                                        >
+                                            Set new password
+                                        </h1>
+                                        <p className="text-sm mt-2" style={{ color: "oklch(0.60 0.03 285)" }}>
+                                            Enter the 6-digit code sent to{" "}
+                                            <span className="font-medium" style={{ color: "oklch(0.78 0.12 290)" }}>
+                                                {emailFromParams || "your email"}
+                                            </span>{" "}
+                                            and choose a new password.
+                                        </p>
+                                    </div>
+
+                                    {/* Form */}
+                                    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+                                        {/* OTP field */}
+                                        <div>
+                                            <label
+                                                htmlFor="reset-otp"
+                                                className="block text-sm font-medium mb-2"
+                                                style={{ color: "oklch(0.70 0.03 285)" }}
+                                            >
+                                                Reset code
+                                            </label>
+                                            <div className="relative">
+                                                <Mail
+                                                    className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4"
+                                                    style={{ color: "oklch(0.45 0.03 285)" }}
+                                                />
+                                                <input
+                                                    id="reset-otp"
+                                                    type="text"
+                                                    inputMode="numeric"
+                                                    maxLength={6}
+                                                    {...register("otp")}
+                                                    placeholder="000000"
+                                                    className={`w-full h-12 pl-10 pr-4 rounded-xl text-sm text-white font-mono tracking-[4px] text-center placeholder:text-[oklch(0.40_0.02_285)] auth-input outline-none transition-all duration-200 ${errors.otp ? "border border-red-500" : ""}`}
+                                                />
+                                            </div>
+                                            {errors.otp && (
+                                                <p className="text-red-500 text-xs mt-1">{errors.otp.message}</p>
+                                            )}
+                                        </div>
+
+                                        {/* New Password */}
+                                        <div>
+                                            <label
+                                                htmlFor="reset-password"
+                                                className="block text-sm font-medium mb-2"
+                                                style={{ color: "oklch(0.70 0.03 285)" }}
+                                            >
+                                                New password
+                                            </label>
+                                            <div className="relative">
+                                                <Lock
+                                                    className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4"
+                                                    style={{ color: "oklch(0.45 0.03 285)" }}
+                                                />
+                                                <input
+                                                    id="reset-password"
+                                                    type={showPassword ? "text" : "password"}
+                                                    {...register("newPassword")}
+                                                    placeholder="••••••••"
+                                                    className={`w-full h-12 pl-10 pr-12 rounded-xl text-sm text-white placeholder:text-[oklch(0.40_0.02_285)] auth-input outline-none transition-all duration-200 ${errors.newPassword ? "border border-red-500" : ""}`}
+                                                />
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setShowPassword(!showPassword)}
+                                                    className="absolute right-3.5 top-1/2 -translate-y-1/2 transition-colors hover:opacity-80"
+                                                    style={{ color: "oklch(0.45 0.03 285)" }}
+                                                >
+                                                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                                </button>
+                                            </div>
+                                            {errors.newPassword && (
+                                                <p className="text-red-500 text-xs mt-1">{errors.newPassword.message}</p>
+                                            )}
+                                        </div>
+
+                                        {/* Confirm Password */}
+                                        <div>
+                                            <label
+                                                htmlFor="reset-confirm-password"
+                                                className="block text-sm font-medium mb-2"
+                                                style={{ color: "oklch(0.70 0.03 285)" }}
+                                            >
+                                                Confirm new password
+                                            </label>
+                                            <div className="relative">
+                                                <Lock
+                                                    className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4"
+                                                    style={{ color: "oklch(0.45 0.03 285)" }}
+                                                />
+                                                <input
+                                                    id="reset-confirm-password"
+                                                    type={showConfirmPassword ? "text" : "password"}
+                                                    {...register("confirmPassword")}
+                                                    placeholder="••••••••"
+                                                    className={`w-full h-12 pl-10 pr-12 rounded-xl text-sm text-white placeholder:text-[oklch(0.40_0.02_285)] auth-input outline-none transition-all duration-200 ${errors.confirmPassword ? "border border-red-500" : ""}`}
+                                                />
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                                                    className="absolute right-3.5 top-1/2 -translate-y-1/2 transition-colors hover:opacity-80"
+                                                    style={{ color: "oklch(0.45 0.03 285)" }}
+                                                >
+                                                    {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                                </button>
+                                            </div>
+                                            {errors.confirmPassword && (
+                                                <p className="text-red-500 text-xs mt-1">{errors.confirmPassword.message}</p>
+                                            )}
+                                        </div>
+
+                                        <button
+                                            type="submit"
+                                            disabled={loading}
+                                            className="w-full h-12 rounded-xl text-[15px] font-semibold text-white transition-all duration-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed hover:brightness-110 active:scale-[0.98] shadow-lg"
+                                            style={{
+                                                background: "linear-gradient(135deg, oklch(0.68 0.15 280), oklch(0.72 0.12 295))",
+                                                boxShadow: "0 4px 20px oklch(0.72 0.12 290 / 25%)",
+                                            }}
+                                        >
+                                            {loading ? "Resetting..." : "Reset password"}
+                                        </button>
+                                    </form>
+                                </>
+                            ) : (
+                                <>
+                                    {/* Success state */}
+                                    <div className="text-center">
+                                        <div
+                                            className="flex h-16 w-16 items-center justify-center rounded-2xl mx-auto mb-5"
+                                            style={{ background: "oklch(0.72 0.18 150 / 15%)" }}
+                                        >
+                                            <ShieldCheck className="h-8 w-8" style={{ color: "oklch(0.75 0.22 150)" }} />
+                                        </div>
+                                        <h2
+                                            className="text-xl font-bold text-white mb-2"
+                                            style={{ fontFamily: "var(--font-heading), sans-serif" }}
+                                        >
+                                            Password reset!
+                                        </h2>
+                                        <p className="text-sm mb-6" style={{ color: "oklch(0.60 0.03 285)" }}>
+                                            Your password has been updated successfully. You can now log in with your new password.
+                                        </p>
+
+                                        <button
+                                            onClick={() => router.push("/login")}
+                                            className="w-full h-12 rounded-xl text-[15px] font-semibold text-white transition-all duration-200 cursor-pointer hover:brightness-110 active:scale-[0.98] shadow-lg"
+                                            style={{
+                                                background: "linear-gradient(135deg, oklch(0.68 0.15 280), oklch(0.72 0.12 295))",
+                                                boxShadow: "0 4px 20px oklch(0.72 0.12 290 / 25%)",
+                                            }}
+                                        >
+                                            Go to login
+                                        </button>
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </BeamsBackground>
+    );
+}
+
+export default function ResetPasswordPage() {
+    return (
+        <Suspense fallback={null}>
+            <ResetPasswordContent />
+        </Suspense>
+    );
+}

--- a/frontend/src/lib/validations.ts
+++ b/frontend/src/lib/validations.ts
@@ -31,3 +31,32 @@ export const registerSchema = z
     });
 
 export type RegisterFormData = z.infer<typeof registerSchema>;
+
+export const forgotPasswordSchema = z.object({
+    email: z
+        .string()
+        .min(1, "Email is required")
+        .email("Please enter a valid email address"),
+});
+
+export type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;
+
+export const resetPasswordSchema = z
+    .object({
+        otp: z
+            .string()
+            .length(6, "OTP must be exactly 6 digits")
+            .regex(/^\d{6}$/, "OTP must be 6 digits"),
+        newPassword: z
+            .string()
+            .min(6, "Password must be at least 6 characters"),
+        confirmPassword: z
+            .string()
+            .min(1, "Please confirm your password"),
+    })
+    .refine((data) => data.newPassword === data.confirmPassword, {
+        message: "Passwords do not match",
+        path: ["confirmPassword"],
+    });
+
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
- Backend: POST /auth/forgot-password and POST /auth/reset-password endpoints
- Backend: purpose-aware OTP (email_verify vs password_reset)
- Backend: send_password_reset_email branded email template
- Backend: update_user_password repo function
- Backend: migration for password_reset OTP purpose enum
- Frontend: /forgot-password page with email input form
- Frontend: /reset-password page with OTP + new password form
- Frontend: 'Forgot password?' link on login page
- Frontend: Zod validation schemas for both forms
- Security: prevents email enumeration on forgot-password endpoint

closes #5 