### PR TITLE
fix(dashboard): prevent redundant API calls for history and favorites

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -113,13 +113,13 @@ function DashboardContent() {
         data: history,
         isLoading: historyLoading,
         refetch: refetchHistory,
-    } = useHistory();
+    } = useHistory(activeTab === "history");
 
     const {
         data: favorites,
         isLoading: favoritesLoading,
         refetch: refetchFavorites,
-    } = useFavorites();
+    } = useFavorites(activeTab === "favorites");
 
     const deleteFavorite = useDeleteFavorite();
 

--- a/frontend/src/hooks/useFavorites.ts
+++ b/frontend/src/hooks/useFavorites.ts
@@ -5,15 +5,18 @@ import api from "@/lib/api";
 import type { FavoriteResponse } from "@/types/api";
 import { useAuthStore } from "@/stores/authStore";
 
-export function useFavorites() {
+export function useFavorites(isActive: boolean = true) {
     const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+    const user = useAuthStore((s) => s.user);
+    
     return useQuery<FavoriteResponse[]>({
         queryKey: ["favorites"],
         queryFn: async () => {
             const { data } = await api.get<FavoriteResponse[]>("/users/me/favorites");
             return data;
         },
-        enabled: isAuthenticated,
+        enabled: isAuthenticated && !!user?.is_verified && isActive,
+        staleTime: 5 * 60 * 1000, // 5 minutes
     });
 }
 

--- a/frontend/src/hooks/useHistory.ts
+++ b/frontend/src/hooks/useHistory.ts
@@ -5,15 +5,18 @@ import api from "@/lib/api";
 import type { HistoryResponse } from "@/types/api";
 import { useAuthStore } from "@/stores/authStore";
 
-export function useHistory() {
+export function useHistory(isActive: boolean = true) {
     const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+    const user = useAuthStore((s) => s.user);
+    
     return useQuery<HistoryResponse[]>({
         queryKey: ["history"],
         queryFn: async () => {
             const { data } = await api.get<HistoryResponse[]>("/users/me/history");
             return data;
         },
-        enabled: isAuthenticated,
+        enabled: isAuthenticated && !!user?.is_verified && isActive,
+        staleTime: 5 * 60 * 1000, // 5 minutes
     });
 }
 


### PR DESCRIPTION
### 1. The Problem Identified
* **Redundant API calls:** When a user visited the Dashboard, both the History and Favorites APIs were being fired simultaneously, even though only one tab was visible at a time.
* **403 Permission Errors:** The API calls were being triggered as soon as the user logged in, without checking if they had verified their email. Unverified users were hitting the endpoints and receiving 403 (Forbidden) errors.
* **Aggressive Refetching (The Tab-Switching Issue):** By default, React Query marks data as "stale" immediately. This meant every time the user switched back to a tab or refocused the browser window, it triggered another API call for data that hadn't changed.

### 2. What I Did
* **Updated the Hooks (`useHistory.ts` & `useFavorites.ts`):** 
  * I added an `isActive` boolean parameter to both hooks.
  * I updated the `enabled` configuration so the query only runs if: `isAuthenticated && !!user?.is_verified && isActive`.
  * I added a `staleTime: 5 * 60 * 1000` (5 minutes) to instruct React Query to cache the responses.
* **Updated the Dashboard (`page.tsx`):**
  * I passed the current tab state into the hooks: `useHistory(activeTab === "history")` and `useFavorites(activeTab === "favorites")`.

### 3. How It Solves the Problem
* **Lazy Loading:** The History API is now strictly called *only* when the History tab is active, and the Favorites API *only* when the Favorites tab is active.
* **No More 403s:** Unverified users will no longer trigger these API calls, entirely eliminating the console errors and backend noise.
* **Smart Caching:** By utilizing the 5-minute `staleTime`, users can now rapidly switch between the History and Favorites tabs without making a single extra API call. 
* **Handling New Searches:** If a user makes a *new* search on the Search page, our existing `useAddHistory` hook will call `queryClient.invalidateQueries(["history"])`. This instantly clears the 5-minute cache, guaranteeing that the next time they open the history tab, it makes one fresh API call to get the latest data.

closes #29 